### PR TITLE
refactor: separate prod config

### DIFF
--- a/src/main/kotlin/com/nullius_real_estate/estate_microservice/controller/EstateController.kt
+++ b/src/main/kotlin/com/nullius_real_estate/estate_microservice/controller/EstateController.kt
@@ -1,7 +1,6 @@
 package com.nullius_real_estate.estate_microservice.controller
 
 import com.nullius_real_estate.estate_microservice.entity.EstateEntity
-import com.nullius_real_estate.estate_microservice.repository.EstateRepository
 import com.nullius_real_estate.estate_microservice.service.EstateService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,1 @@
+logging.level.org.hibernate.SQL=DEBUG

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,16 @@
+eureka.instance.hostname=${EUREKA_INSTANCE_HOSTNAME:localhost}
+
+eureka.instance.prefer-ip-address=false
+eureka.instance.non-secure-port-enabled=false
+eureka.instance.secure-port-enabled=true
+eureka.instance.secure-port=${PORT:443}
+eureka.instance.home-page-url=https://${eureka.instance.hostname}/
+eureka.instance.status-page-url=https://${eureka.instance.hostname}/actuator/info
+eureka.instance.health-check-url=https://${eureka.instance.hostname}/actuator/health
+
+# Disable automatic hostname resolution
+eureka.instance.metadata-map.hostname=${eureka.instance.hostname}
+eureka.instance.metadata-map.port=${PORT:443}
+eureka.instance.metadata-map.securePort=443
+
+logging.level.org.hibernate.SQL=INFO

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,22 +1,9 @@
 spring.application.name=estate-microservice
 server.port=${PORT:0}
 
-eureka.instance.hostname=${EUREKA_INSTANCE_HOSTNAME:localhost}
-eureka.instance.prefer-ip-address=false
-eureka.instance.non-secure-port-enabled=false
-eureka.instance.secure-port-enabled=true
-eureka.instance.secure-port=${PORT:443}
-eureka.instance.home-page-url=https://${eureka.instance.hostname}/
-eureka.instance.status-page-url=https://${eureka.instance.hostname}/actuator/info
-eureka.instance.health-check-url=https://${eureka.instance.hostname}/actuator/health
 eureka.instance.instance-id=${spring.application.name}:${random.uuid}
 eureka.client.enabled=true
 eureka.client.service-url.defaultZone=${EUREKA_URL:http://localhost:8761/eureka}
-
-# Disable automatic hostname resolution
-eureka.instance.metadata-map.hostname=${eureka.instance.hostname}
-eureka.instance.metadata-map.port=${PORT:443}
-eureka.instance.metadata-map.securePort=443
 
 spring.datasource.url=${DATABASE_URL:jdbc:postgresql://localhost:5432/db_real_estate}
 spring.datasource.username=${DB_USERNAME:postgres}
@@ -28,8 +15,6 @@ spring.jpa.show-sql=false
 spring.jpa.generate-ddl=true
 spring.jpa.hibernate.ddl-auto=update
 spring.sql.init.platform=postgres
-
-logging.level.org.hibernate.SQL=INFO
 
 # Documentation
 springdoc.api-docs.path=/api/estate/v3/api-docs


### PR DESCRIPTION
This pull request includes several changes to the `estate_microservice` project, focusing on configuration updates and code cleanup. The most important changes are grouped by theme below:

Configuration updates:

* [`src/main/resources/application-prod.properties`](diffhunk://#diff-53e0fee6660a4a2a0f74370f5a08f37733746fd612eca8c9df7ebd0dfdb613efR1-R16): Added several properties for configuring Eureka instance settings and logging level for Hibernate SQL.
* [`src/main/resources/application-local.properties`](diffhunk://#diff-4d8bbe5db39e2956bb9e178c5a8105fcfd99ce2f027450fa47e22083d6849221R1): Set the logging level for Hibernate SQL to DEBUG.

Code cleanup:

* [`src/main/kotlin/com/nullius_real_estate/estate_microservice/controller/EstateController.kt`](diffhunk://#diff-306b367f177a63896182d09fb3f21d5027ca1c2398ddb3bd75165ce565ca2cb5L4): Removed unused import of `EstateRepository`.
* [`src/main/resources/application.properties`](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136L4-L20): Removed redundant Eureka instance configuration properties and logging level for Hibernate SQL. [[1]](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136L4-L20) [[2]](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136L32-L33)